### PR TITLE
Make imports compatible with python 2 and 3

### DIFF
--- a/pygments_solarized/__init__.py
+++ b/pygments_solarized/__init__.py
@@ -1,5 +1,7 @@
-from light import SolarizedStyle
-from dark import SolarizedDarkStyle
-from dark256 import SolarizedDark256Style
+from __future__ import absolute_import
+
+from .light import SolarizedStyle
+from .dark import SolarizedDarkStyle
+from .dark256 import SolarizedDark256Style
 
 __version__ = '0.0.2'


### PR DESCRIPTION
Imported absolute_import from __future__ so that python 2 and 3 imports will behave the same.  Updated imports in pygments_solarized/__init__.py to use dot notation to be compatible with the newer absolute_import style.